### PR TITLE
Fix NullPointer exception in SectionServlet

### DIFF
--- a/src/main/java/com/google/collegeplanner/servlets/SectionServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/SectionServlet.java
@@ -28,7 +28,6 @@ import org.json.simple.JSONObject;
 /** Servlet that returns list of course sections.*/
 @WebServlet("/api/sections")
 public class SectionServlet extends BaseServlet {
-  ApiUtil apiUtil;
 
   public SectionServlet() {
     super(new ApiUtil());


### PR DESCRIPTION
The recent BaseServlet merge causes a NullPointerException when accessing the `/sections` endpoint. The fix is to just remove the `apiUtil` variable from `SectionServlet.java` because it already exists in the parent class `BaseServlet.java`