### PR TITLE
Verify tokens on back end and save plans to Datastore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
       <artifactId>google-http-client-gson</artifactId>
       <version>1.23.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.64</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,26 @@
       <version>1.23.0</version>
     </dependency>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datastore</artifactId>
+      <version>1.104.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-testing</artifactId>
       <version>1.9.64</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.60</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>1.9.60</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,21 @@
       <artifactId>jsonassert</artifactId>
       <version>1.5.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.30.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client-appengine</artifactId>
+      <version>1.30.10</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-gson</artifactId>
+      <version>1.23.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/collegeplanner/data/Plan.java
+++ b/src/main/java/com/google/collegeplanner/data/Plan.java
@@ -14,16 +14,16 @@
 
 package com.google.collegeplanner.data;
 
+import org.json.simple.JSONObject;
+
 public class Plan {
   private final long id;
-  private final String plan;
+  private final JSONObject plan;
   private final String planName;
-  private final String timestamp;
 
-  public Plan(long id, String plan, String planName, String timestamp) {
+  public Plan(long id, JSONObject plan, String planName) {
     this.id = id;
     this.plan = plan;
     this.planName = planName;
-    this.timestamp = timestamp;
   }
 }

--- a/src/main/java/com/google/collegeplanner/data/Plan.java
+++ b/src/main/java/com/google/collegeplanner/data/Plan.java
@@ -16,6 +16,7 @@ package com.google.collegeplanner.data;
 
 import org.json.simple.JSONObject;
 
+/** This class represents a multi-semester plan. */
 public class Plan {
   private final long id;
   private final JSONObject plan;

--- a/src/main/java/com/google/collegeplanner/data/Plan.java
+++ b/src/main/java/com/google/collegeplanner/data/Plan.java
@@ -18,10 +18,12 @@ import org.json.simple.JSONObject;
 
 /** This class represents a multi-semester plan. */
 public class Plan {
-  private final long id; // The id of the Plan in Datastore.
-  private final JSONObject
-      plan; // The JSONObject that contains the plan details (courses and credits).
-  private final String planName; // The name the user specified for the plan
+  // The id of the Plan in Datastore.
+  private final long id;
+  // The JSONObject that contains the plan details (courses and credits).
+  private final JSONObject plan;
+  // The name the user specified for the plan
+  private final String planName;
 
   public Plan(long id, JSONObject plan, String planName) {
     this.id = id;

--- a/src/main/java/com/google/collegeplanner/data/Plan.java
+++ b/src/main/java/com/google/collegeplanner/data/Plan.java
@@ -18,9 +18,10 @@ import org.json.simple.JSONObject;
 
 /** This class represents a multi-semester plan. */
 public class Plan {
-  private final long id;
-  private final JSONObject plan;
-  private final String planName;
+  private final long id; // The id of the Plan in Datastore.
+  private final JSONObject
+      plan; // The JSONObject that contains the plan details (courses and credits).
+  private final String planName; // The name the user specified for the plan
 
   public Plan(long id, JSONObject plan, String planName) {
     this.id = id;

--- a/src/main/java/com/google/collegeplanner/data/Plan.java
+++ b/src/main/java/com/google/collegeplanner/data/Plan.java
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package com.google.collegeplanner.data;
+
+package com.google.collegeplanner.data;
+
+public class Plan {
+  private final long id;
+  private final String plan;
+  private final String planName;
+  private final String timestamp;
+
+  public Plan(long id, String plan, String planName, String timestamp) {
+    this.id = id;
+    this.plan = plan;
+    this.planName = planName;
+    this.timestamp = timestamp;
+  }
+}

--- a/src/main/java/com/google/collegeplanner/servlets/BaseServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/BaseServlet.java
@@ -90,7 +90,7 @@ public abstract class BaseServlet extends HttpServlet {
   /**
    * Gets the JSON Representation of the body of the POST request
    */
-  public JSONObject getBody(HttpServletRequest request)
+  public JSONObject getPostRequestBody(HttpServletRequest request)
       throws IOException, ParseException, NullPointerException {
     String strBody =
         request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));

--- a/src/main/java/com/google/collegeplanner/servlets/BaseServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/BaseServlet.java
@@ -16,9 +16,13 @@ package com.google.collegeplanner.servlets;
 
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 /** Provides an interface for shared logic between the servlets. */
 public abstract class BaseServlet extends HttpServlet {
@@ -81,5 +85,16 @@ public abstract class BaseServlet extends HttpServlet {
     response.setStatus(status);
     response.setContentType("application/json;");
     response.getWriter().println(new Gson().toJson(jsonObject));
+  }
+
+  /**
+   * Gets the JSON Representation of the body of the POST request
+   */
+  public JSONObject getBody(HttpServletRequest request)
+      throws IOException, ParseException, NullPointerException {
+    String strBody =
+        request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
+    JSONParser parser = new JSONParser();
+    return (JSONObject) parser.parse(strBody);
   }
 }

--- a/src/main/java/com/google/collegeplanner/servlets/PlannerServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/PlannerServlet.java
@@ -54,7 +54,7 @@ public class PlannerServlet extends BaseServlet {
     int numSemesters;
     JSONArray selectedClasses;
     try {
-      body = getBody(request);
+      body = getPostRequestBody(request);
       numSemesters = Integer.parseInt((String) body.get("semesters"));
       selectedClasses = (JSONArray) body.get("selectedClasses");
     } catch (NumberFormatException | ClassCastException | ParseException | NullPointerException e) {

--- a/src/main/java/com/google/collegeplanner/servlets/PlannerServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/PlannerServlet.java
@@ -138,17 +138,6 @@ public class PlannerServlet extends BaseServlet {
   }
 
   /**
-   * Gets the JSON Representation of the body of the POST request
-   */
-  private JSONObject getBody(HttpServletRequest request)
-      throws IOException, ParseException, NullPointerException {
-    String strBody =
-        request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
-    JSONParser parser = new JSONParser();
-    return (JSONObject) parser.parse(strBody);
-  }
-
-  /**
    * Creates the representation for the graph and reads/stores necessary information from
    * selectedClasses
    * @param selectedClasses JSONArray that contains details for all of the courses selected by the

--- a/src/main/java/com/google/collegeplanner/servlets/SavePlanServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/SavePlanServlet.java
@@ -22,12 +22,21 @@ import com.google.api.client.json.gson.GsonFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.collegeplanner.data.Plan;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -36,12 +45,11 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
 
-/** Servlet that returns list of course sections.*/
+/** Servlet that saves and returns a users plans.*/
 @WebServlet("/api/planner/save")
 public class SavePlanServlet
-    extends BaseServlet { /**
-                           * Reads from Datastore and returns response with section details
-                           */
+    extends BaseServlet { 
+
   GoogleIdTokenVerifier verifier;
   DatastoreService datastore;
 
@@ -60,7 +68,39 @@ public class SavePlanServlet
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // TODO(ramyabuva): Get users saved plans.
+    GoogleIdToken idToken;
+    try {
+      idToken = verifier.verify(request.getParameter("idToken"));
+    } catch (GeneralSecurityException e) {
+      respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
+      return;
+    }
+
+    if (idToken == null) {
+      respondWithError("Invalid user.", HttpServletResponse.SC_BAD_REQUEST, response);
+      return;
+    }
+
+    Payload payload = idToken.getPayload();
+    Query query =
+        new Query("Plan")
+            .setFilter(new FilterPredicate("user", FilterOperator.EQUAL, payload.getEmail()))
+            .addSort("timestamp", SortDirection.DESCENDING);
+    List<Entity> results = datastore.prepare(query).asList(FetchOptions.Builder.withDefaults());
+
+    ArrayList<Plan> plans = new ArrayList<>();
+    for (Entity entity : results) {
+      long id = entity.getKey().getId();
+      String plan = (String) entity.getProperty("plan");
+      String planName = (String) entity.getProperty("planName");
+      String timestamp = (String) entity.getProperty("timestamp");
+      plans.add(new Plan(id, plan, planName, timestamp));
+    }
+    JSONObject plansJson = new JSONObject();
+    plansJson.put("plans", new Gson().toJson(plans));
+    plansJson.put("user", payload.getEmail());
+    response.setContentType("application/json");
+    response.getWriter().println(new Gson().toJson(plansJson));
   }
 
   @Override
@@ -84,18 +124,25 @@ public class SavePlanServlet
     try {
       idToken = verifier.verify(idTokenStr);
     } catch (GeneralSecurityException e) {
+      respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
       return;
     }
 
-    if (idToken != null) {
-      Payload payload = idToken.getPayload();
-      addToDatastore(payload.getEmail(), plan, planName);
-    } else {
+    if (idToken == null) {
       respondWithError("Invalid user.", HttpServletResponse.SC_BAD_REQUEST, response);
       return;
     }
+
+    Payload payload = idToken.getPayload();
+    addToDatastore(payload.getEmail(), plan, planName);
   }
 
+  /**
+   * Writes the saved plan to datastore.
+   * @param email The email associated with the plan.
+   * @param plan The plan that was saved.
+   * @param planName the name the user tried to save their plan with.
+   */
   private void addToDatastore(String email, String plan, String planName) {
     long timestamp = System.currentTimeMillis();
     Entity planEntity = new Entity("Plan");

--- a/src/main/java/com/google/collegeplanner/servlets/SavePlanServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/SavePlanServlet.java
@@ -53,14 +53,19 @@ public class SavePlanServlet extends BaseServlet {
    * Verifier for Google OAuth that validates tokens and ensures the source of the token is
    * acceptable according to the client ID.
    */
-  final GoogleIdTokenVerifier verifier;
+  GoogleIdTokenVerifier verifier;
   DatastoreService datastore;
+  /**
+   * Public identifier for this app to use Google OAuth 2.0. It is found in cloud console
+   * credentials.
+   */
+  final static String clientId =
+      "267429534228-vvsi2uldmpji3rgs1qd3a41rceciaaaq.apps.googleusercontent.com";
 
   public SavePlanServlet() {
     this(DatastoreServiceFactory.getDatastoreService(),
         new GoogleIdTokenVerifier.Builder(UrlFetchTransport.getDefaultInstance(), new GsonFactory())
-            .setAudience(Collections.singletonList(
-                "267429534228-vvsi2uldmpji3rgs1qd3a41rceciaaaq.apps.googleusercontent.com"))
+            .setAudience(Collections.singletonList(clientId))
             .build());
   }
 

--- a/src/main/java/com/google/collegeplanner/servlets/SavePlanServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/SavePlanServlet.java
@@ -132,7 +132,7 @@ public class SavePlanServlet extends BaseServlet {
     String planName;
     JSONObject body;
     try {
-      body = getBody(request);
+      body = getPostRequestBody(request);
       idTokenStr = (String) body.get("idToken");
       planName = (String) body.get("planName");
       plan = ((JSONObject) body.get("plan")).toString();

--- a/src/main/java/com/google/collegeplanner/servlets/SavePlanServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/SavePlanServlet.java
@@ -1,0 +1,88 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.collegeplanner.servlets;
+
+import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.ParseException;
+
+/** Servlet that returns list of course sections.*/
+@WebServlet("/api/planner/save")
+public class SavePlanServlet
+    extends BaseServlet { /**
+                           * Reads from Datastore and returns response with section details
+                           */
+  GoogleIdTokenVerifier verifier;
+
+  public SavePlanServlet() {
+    this(
+        new GoogleIdTokenVerifier.Builder(UrlFetchTransport.getDefaultInstance(), new GsonFactory())
+            .setAudience(Collections.singletonList(
+                "267429534228-vvsi2uldmpji3rgs1qd3a41rceciaaaq.apps.googleusercontent.com"))
+            .build());
+  }
+
+  public SavePlanServlet(GoogleIdTokenVerifier verifier) {
+    this.verifier = verifier;
+  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String idTokenStr;
+    String plan;
+    String planName;
+    JSONObject body;
+    try {
+      body = getBody(request);
+      idTokenStr = (String) body.get("idToken");
+      planName = (String) body.get("planName");
+      plan = ((JSONObject) body.get("plan")).toString();
+    } catch (ClassCastException | ParseException | NullPointerException e) {
+      respondWithError(
+          "Invalid body for POST request.", HttpServletResponse.SC_BAD_REQUEST, response);
+      return;
+    }
+
+    GoogleIdToken idToken;
+    try {
+      idToken = verifier.verify(idTokenStr);
+    } catch (Throwable e) {
+      return;
+    }
+
+    if (idToken != null) {
+      Payload payload = idToken.getPayload();
+      String email = payload.getEmail();
+      System.out.println(email);
+    } else {
+      respondWithError("Invalid user.", HttpServletResponse.SC_BAD_REQUEST, response);
+      return;
+    }
+  }
+}

--- a/src/main/webapp/js/pages/planner.js
+++ b/src/main/webapp/js/pages/planner.js
@@ -93,6 +93,9 @@ async function savePlan(courseList) {
     });
     $('#savePlanModal').modal('hide');
   } catch (err) {
+    CollegePlanner.createAlert(
+        'Could not save this plan', 'warning',
+        document.getElementById('plan-name'));
     return;
   }
 }

--- a/src/main/webapp/js/pages/planner.js
+++ b/src/main/webapp/js/pages/planner.js
@@ -74,9 +74,27 @@ async function getPlan() {
  * @param {Object} courseList JSON Object containing the courseplan returned by
  *     the servlet.
  */
-function savePlan(courseList) {
-  // TODO(#77): Send tokens to servlet to save plans in Datastore.
-  console.log(courseList);
+async function savePlan(courseList) {
+  if (!gapi.auth2.getAuthInstance().isSignedIn.get()) {
+    return;
+  }
+  const data = {
+    idToken: gapi.auth2.getAuthInstance()
+                 .currentUser.get()
+                 .getAuthResponse()
+                 .id_token,
+    plan: courseList,
+    planName: document.getElementById('save-plan-as').value
+  };
+  try {
+    await fetch('/api/planner/save', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    $('#savePlanModal').modal('hide');
+  } catch (err) {
+    return;
+  }
 }
 
 /**

--- a/src/main/webapp/savedPlanners.jsp
+++ b/src/main/webapp/savedPlanners.jsp
@@ -1,0 +1,21 @@
+<%-- 
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+<jsp:param name="directory" value="../"/>
+--%>
+<jsp:include page="/vendor/startbootstrap/template.jsp">
+  <jsp:param name="activePlanner" value="active"/>
+  <jsp:param name="content" value="saved-planner-content"/>
+  <jsp:param name="scriptFile" value="pages/savedPlanners"/>
+</jsp:include>

--- a/src/main/webapp/vendor/startbootstrap/planner-content.jsp
+++ b/src/main/webapp/vendor/startbootstrap/planner-content.jsp
@@ -109,7 +109,7 @@
       </div>
       <div class="modal-body">
         <form id="plan-name" onsubmit="return false">
-          <input type="text" class="form-control" placeholder="Type name here" required></input>
+          <input type="text" class="form-control" placeholder="Type name here" id="save-plan-as" required></input>
         </form>
       </div>
       <div class="modal-footer">

--- a/src/main/webapp/vendor/startbootstrap/planner-content.jsp
+++ b/src/main/webapp/vendor/startbootstrap/planner-content.jsp
@@ -137,3 +137,22 @@
     </div>
   </div>
 </div>
+<!-- Sign in Prompt Modal -->
+<div class="modal fade" id="signInModal" tabindex="-1" role="dialog" aria-labelledby="signInModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="signInModalLabel">Sign in to see your saved schedules.</h5>
+      </div>
+      <div class="modal-body">
+        <center>
+          <div class="g-signin2" data-onsuccess="onSignIn"></div>
+        </center>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" type="button" data-dismiss="modal">Dismiss</button>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/src/test/java/com/google/collegeplanner/CourseListServletTest.java
+++ b/src/test/java/com/google/collegeplanner/CourseListServletTest.java
@@ -44,7 +44,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /** Tests CourseListServlet */
 @RunWith(JUnit4.class)
-public final class CourseListTest {
+public final class CourseListServletTest {
   HttpServletRequest mockedRequest;
   HttpServletResponse mockedResponse;
   StringWriter stringWriter;

--- a/src/test/java/com/google/collegeplanner/DepartmentServletTest.java
+++ b/src/test/java/com/google/collegeplanner/DepartmentServletTest.java
@@ -44,7 +44,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /** Tests DepartmentServlet */
 @RunWith(JUnit4.class)
-public final class DepartmentTest {
+public final class DepartmentServletTest {
   HttpServletResponse mockedResponse;
   StringWriter stringWriter;
   PrintWriter writer;

--- a/src/test/java/com/google/collegeplanner/PlannerServletTest.java
+++ b/src/test/java/com/google/collegeplanner/PlannerServletTest.java
@@ -43,7 +43,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /** Tests PlannerServlet */
 @RunWith(JUnit4.class)
-public final class PlannerTest {
+public final class PlannerServletTest {
   HttpServletRequest mockedRequest;
   HttpServletResponse mockedResponse;
   StringWriter stringWriter;

--- a/src/test/java/com/google/collegeplanner/SavePlanServletTest.java
+++ b/src/test/java/com/google/collegeplanner/SavePlanServletTest.java
@@ -60,7 +60,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /** Test SavePlanServlet */
 @RunWith(JUnit4.class)
-public final class SavePlanTest {
+public final class SavePlanServletTest {
   HttpServletResponse response;
   HttpServletRequest request;
   StringWriter stringWriter;

--- a/src/test/java/com/google/collegeplanner/SavePlanTest.java
+++ b/src/test/java/com/google/collegeplanner/SavePlanTest.java
@@ -121,8 +121,8 @@ public final class SavePlanTest {
     when(request.getReader()).thenReturn(reader);
     when(verifier.verify("PERSON_A")).thenReturn(null);
     servlet.doPost(request, response);
-    verify(response, times(1)).setStatus(HttpServletResponse.SC_BAD_REQUEST);
-    verify(response, never()).setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
+    verify(response, times(1)).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(response, never()).setStatus(not(eq(HttpServletResponse.SC_UNAUTHORIZED)));
     // Check whether the string output is correct.
     JSONAssert.assertEquals(stringWriter.toString(),
         "{\"message\":\"Invalid user.\",\"status\":\"error\"}", JSONCompareMode.STRICT);
@@ -193,8 +193,8 @@ public final class SavePlanTest {
     when(request.getParameter("idToken")).thenReturn("PERSON_A");
     when(verifier.verify("PERSON_A")).thenReturn(null);
     servlet.doGet(request, response);
-    verify(response, times(1)).setStatus(HttpServletResponse.SC_BAD_REQUEST);
-    verify(response, never()).setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
+    verify(response, times(1)).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(response, never()).setStatus(not(eq(HttpServletResponse.SC_UNAUTHORIZED)));
     // Check whether the string output is correct.
     JSONAssert.assertEquals(stringWriter.toString(),
         "{\"message\":\"Invalid user.\",\"status\":\"error\"}", JSONCompareMode.STRICT);

--- a/src/test/java/com/google/collegeplanner/SavePlanTest.java
+++ b/src/test/java/com/google/collegeplanner/SavePlanTest.java
@@ -1,0 +1,202 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.collegeplanner;
+
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.collegeplanner.servlets.SavePlanServlet;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.http.client.utils.URIBuilder;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+/** Test SavePlanServlet */
+@RunWith(JUnit4.class)
+public final class SavePlanTest {
+  HttpServletResponse response;
+  HttpServletRequest request;
+  StringWriter stringWriter;
+  PrintWriter writer;
+  JSONParser parser;
+  DatastoreService datastore;
+  GoogleIdTokenVerifier verifier;
+  SavePlanServlet servlet;
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  @Before
+  public void before() throws Exception {
+    datastore = DatastoreServiceFactory.getDatastoreService();
+    response = mock(HttpServletResponse.class);
+    request = mock(HttpServletRequest.class);
+    stringWriter = new StringWriter();
+    writer = new PrintWriter(stringWriter);
+    parser = new JSONParser();
+    when(response.getWriter()).thenReturn(writer);
+    verifier = mock(GoogleIdTokenVerifier.class);
+    servlet = new SavePlanServlet(datastore, verifier);
+    helper.setUp();
+  }
+
+  @After
+  public void after() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void servletAddsObjectToDatastore() throws Exception {
+    // We're simulating a POST request to the servlet.
+    String test = "{\"idToken\": \"PERSON_A\", \"planName\": \"plan1\","
+        + " \"plan\": {\"semester_plan\":[[\"AASP100\"]], "
+        + "\"semester_credits\": [3]}}";
+    Reader inputString = new StringReader(test);
+    BufferedReader reader = new BufferedReader(inputString);
+    when(request.getReader()).thenReturn(reader);
+    GoogleIdToken idToken = mock(GoogleIdToken.class);
+    when(verifier.verify("PERSON_A")).thenReturn(idToken);
+    Payload payload = mock(Payload.class);
+    when(idToken.getPayload()).thenReturn(payload);
+    when(payload.getEmail()).thenReturn("persona@gmail.com");
+    servlet.doPost(request, response);
+    Assert.assertEquals(1, datastore.prepare(new Query("Plan")).countEntities());
+  }
+
+  @Test
+  public void postReturnsErrorInvalidToken() throws Exception {
+    // We're simulating a POST request to the servlet.
+    String test = "{\"idToken\": \"PERSON_A\", \"planName\": \"plan1\","
+        + " \"plan\": {\"semester_plan\":[[\"AASP100\"]], "
+        + "\"semester_credits\": [3]}}";
+    Reader inputString = new StringReader(test);
+    BufferedReader reader = new BufferedReader(inputString);
+    when(request.getReader()).thenReturn(reader);
+    when(verifier.verify("PERSON_A")).thenReturn(null);
+    servlet.doPost(request, response);
+    verify(response, times(1)).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    verify(response, never()).setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
+    // Check whether the string output is correct.
+    JSONAssert.assertEquals(stringWriter.toString(),
+        "{\"message\":\"Invalid user.\",\"status\":\"error\"}", JSONCompareMode.STRICT);
+  }
+
+  @Test
+  public void postReturnsErrorInvalidBody() throws Exception {
+    // We're simulating a POST request to the servlet.
+    String test = "{}";
+    Reader inputString = new StringReader(test);
+    BufferedReader reader = new BufferedReader(inputString);
+    when(request.getReader()).thenReturn(reader);
+    servlet.doPost(request, response);
+    verify(response, times(1)).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    verify(response, never()).setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
+    // Check whether the string output is correct.
+    JSONAssert.assertEquals(stringWriter.toString(),
+        "{\"message\":\"Invalid body for POST request.\",\"status\":\"error\"}",
+        JSONCompareMode.STRICT);
+  }
+
+  @Test
+  public void servletGetsOnlyUsersPlans() throws Exception {
+    // Simulate two post requests from different users.
+    String testA = "{\"idToken\": \"PERSON_A\", \"planName\": \"plan1\","
+        + " \"plan\": {\"semester_plan\":[[\"AASP100\"]], "
+        + "\"semester_credits\": [3]}}";
+    Reader inputStringA = new StringReader(testA);
+    BufferedReader readerA = new BufferedReader(inputStringA);
+    when(request.getReader()).thenReturn(readerA);
+    GoogleIdToken idTokenA = mock(GoogleIdToken.class);
+    when(verifier.verify("PERSON_A")).thenReturn(idTokenA);
+    Payload payloadA = mock(Payload.class);
+    when(idTokenA.getPayload()).thenReturn(payloadA);
+    when(payloadA.getEmail()).thenReturn("persona@gmail.com");
+    servlet.doPost(request, response);
+    Assert.assertEquals(1, datastore.prepare(new Query("Plan")).countEntities());
+
+    String testB = "{\"idToken\": \"PERSON_B\", \"planName\": \"plan2\","
+        + " \"plan\": {\"semester_plan\":[[\"CMSC101\"]], "
+        + "\"semester_credits\": [4]}}";
+    Reader inputStringB = new StringReader(testB);
+    BufferedReader readerB = new BufferedReader(inputStringB);
+    when(request.getReader()).thenReturn(readerB);
+    GoogleIdToken idTokenB = mock(GoogleIdToken.class);
+    when(verifier.verify("PERSON_B")).thenReturn(idTokenB);
+    Payload payloadB = mock(Payload.class);
+    when(idTokenB.getPayload()).thenReturn(payloadB);
+    when(payloadB.getEmail()).thenReturn("personb@gmail.com");
+    servlet.doPost(request, response);
+    Assert.assertEquals(2, datastore.prepare(new Query("Plan")).countEntities());
+
+    // Execute get request for PERSON_B.
+    when(request.getParameter("idToken")).thenReturn("PERSON_B");
+    servlet.doGet(request, response);
+    System.out.println(stringWriter.toString());
+    JSONAssert.assertEquals(stringWriter.toString(),
+        "{\"plans\":\"[{\\\"id\\\":2,"
+            + "\\\"plan\\\":{\\\"semester_credits\\\":[4],"
+            + "\\\"semester_plan\\\":[[\\\"CMSC101\\\"]]},"
+            + "\\\"planName\\\":\\\"plan2\\\"}]\",\"user\":\"personb@gmail.com\"}",
+        JSONCompareMode.STRICT);
+  }
+
+  @Test
+  public void getReturnsErrorInvalidToken() throws Exception {
+    // We're simulating a GET request to the servlet.
+    when(request.getParameter("idToken")).thenReturn("PERSON_A");
+    when(verifier.verify("PERSON_A")).thenReturn(null);
+    servlet.doGet(request, response);
+    verify(response, times(1)).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    verify(response, never()).setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
+    // Check whether the string output is correct.
+    JSONAssert.assertEquals(stringWriter.toString(),
+        "{\"message\":\"Invalid user.\",\"status\":\"error\"}", JSONCompareMode.STRICT);
+  }
+}

--- a/src/test/java/com/google/collegeplanner/ScheduleTest.java
+++ b/src/test/java/com/google/collegeplanner/ScheduleTest.java
@@ -134,7 +134,7 @@ public final class ScheduleTest {
     Assert.assertTrue(actual.addClass(compSciClass));
     Assert.assertTrue(actual.addClass(englishClass));
     actual.removeLastClass();
-    
+
     Schedule expected = new Schedule();
     Assert.assertTrue(expected.addClass(compSciClass));
     Assert.assertEquals(expected, actual);


### PR DESCRIPTION
I created a new SavePlanServlet.java to allow users to save their schedules into Datastore. To save, planner.js sends a POST request that verifies that the user authentication token is valid, and if so, saves the desired plan into Datastore. The saved plans can then be retrieved with a GET request, that also verifies the authentication token and returns the proper entities from Datastore.

I also moved getBody(), a function that gets the body of a POST request, into BaseServlet, so it can be used for all servlets.

closes #77 