### PR TITLE
Let CourseListServlet and SectionServlet pull data from datastore

### DIFF
--- a/src/main/java/com/google/collegeplanner/data/Course.java
+++ b/src/main/java/com/google/collegeplanner/data/Course.java
@@ -14,6 +14,9 @@
 
 package com.google.collegeplanner.data;
 
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.appengine.api.datastore.Entity;
+import com.google.gson.annotations.SerializedName;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
@@ -25,63 +28,68 @@ public class Course {
    * courseId represents the name of the course that
    * can be found on the course catalog. Example, ENGL101
    */
-  private String courseId;
+  @SerializedName("course_id") private String courseId;
   /*
    * name represents the full name of the course.
    * Example, Academic Writing
    */
-  private String name;
+  @SerializedName("name") private String name;
   /*
    * semester represents the 4 digit year followed by
    * the two digit month when the course starts. Example, 202008
    */
-  private String semester;
+  @SerializedName("semester") private String semester;
   /*
    * credits represents the number of credits the course is worth.
    */
-  private int credits;
+  @SerializedName("credits") private int credits;
   /*
    * departmentId represents the 4 character ID of the
    * department that the class falls into. Example, ENGL
    */
-  private String departmentId;
+  @SerializedName("dept_id") private String departmentId;
   /*
    * description represents the description of
    * the class found on the course catalog.
    */
-  private String description;
+  @SerializedName("description") private String description;
   /*
    * corequisites represents the corequisite classes for this
    * course. Example, BIO106 is the lab for BIO101 and
    * must be taken together
    */
-  private String corequisites;
+  @SerializedName("coreqs") private String corequisites;
   /*
    * prerequisites represents the prerequisite classes for
    * this course. Example, MATH101, MATH201, and
    * either MATH105 or MATH115.
    */
-  private String prerequisites;
+  @SerializedName("prereqs") private String prerequisites;
   /*
    * restrictions represents the restrictions placed on the
    * registration of this course. Example, This
    * class is only avaiable to incoming Freshman.
    */
-  private String restrictions;
+  @SerializedName("restrictions") private String restrictions;
   /*
    * additionalInfo represents the additional information
    * for this course found on the course catalog.
    */
-  private String additionalInfo;
+  @SerializedName("additional_info") private String additionalInfo;
   /*
    *creditGrantedFor represents the classes this course
    * grants credit for. Example, THET285 grants credit for COMM107
    */
-  private String creditGrantedFor;
+  @SerializedName("credit_granted_for") private String creditGrantedFor;
+
+  /*
+   * sections used for deserializing datastore Entities to be converted into JSON.
+   */
+  @SerializedName("sections") private Section[] sections;
 
   public Course(String courseId, String name, String semester, int credits, String departmentId,
       String description, String corequisites, String prerequisites, String restrictions,
-      String additionalInfo, String creditGrantedFor) throws Exception {
+      String additionalInfo, String creditGrantedFor) throws ParseException {
     this.courseId = courseId;
     this.name = name;
     this.semester = semester;
@@ -107,7 +115,7 @@ public class Course {
     this.courseId = (String) json.get("course_id");
     this.name = (String) json.get("name");
     this.semester = (String) json.get("semester");
-    this.departmentId = (String) json.get("department_id");
+    this.departmentId = (String) json.get("dept_id");
     this.description = (String) json.get("description");
 
     JSONObject relationships = (JSONObject) json.get("relationships");
@@ -128,6 +136,32 @@ public class Course {
 
     validate();
   }
+
+  public Course(Entity courseEntity) throws ParseException {
+    this((String) courseEntity.getProperty("course_id"), (String) courseEntity.getProperty("name"),
+        (String) courseEntity.getProperty("semester"),
+        ((Long) courseEntity.getProperty("credits")).intValue(),
+        (String) courseEntity.getProperty("dept_id"),
+        (String) courseEntity.getProperty("description"),
+        (String) courseEntity.getProperty("coreqs"), (String) courseEntity.getProperty("prereqs"),
+        (String) courseEntity.getProperty("restrictions"),
+        (String) courseEntity.getProperty("additional_info"),
+        (String) courseEntity.getProperty("credit_granted_for"));
+    // Datastore stores ints as longs.
+    // this.credits = ((Long) courseEntity.getProperty("credits")).intValue();
+    // this.courseId = (String) courseEntity.getProperty("course_id");
+    // this.name = (String) courseEntity.getProperty("name");
+    // this.semester = (String) courseEntity.getProperty("semester");
+    // this.departmentId = (String) courseEntity.getProperty("dept_id");
+    // this.description = (String) courseEntity.getProperty("description");
+    // this.corequisites = (String) courseEntity.getProperty("coreqs");
+    // this.prerequisites = (String) courseEntity.getProperty("prereqs");
+    // this.restrictions = (String) courseEntity.getProperty("restrictions");
+    // this.additionalInfo = (String) courseEntity.getProperty("additional_info");
+    // this.creditGrantedFor = (String) courseEntity.getProperty("credit_granted_for");
+  }
+
+  public Course(Entity courseEntity, ArrayList<EmbeddedEntity> sections) {}
 
   /*
    * Validates the courseId parameter that is passed into the constructors.

--- a/src/main/java/com/google/collegeplanner/data/Course.java
+++ b/src/main/java/com/google/collegeplanner/data/Course.java
@@ -147,18 +147,6 @@ public class Course {
         (String) courseEntity.getProperty("restrictions"),
         (String) courseEntity.getProperty("additional_info"),
         (String) courseEntity.getProperty("credit_granted_for"));
-    // Datastore stores ints as longs.
-    // this.credits = ((Long) courseEntity.getProperty("credits")).intValue();
-    // this.courseId = (String) courseEntity.getProperty("course_id");
-    // this.name = (String) courseEntity.getProperty("name");
-    // this.semester = (String) courseEntity.getProperty("semester");
-    // this.departmentId = (String) courseEntity.getProperty("dept_id");
-    // this.description = (String) courseEntity.getProperty("description");
-    // this.corequisites = (String) courseEntity.getProperty("coreqs");
-    // this.prerequisites = (String) courseEntity.getProperty("prereqs");
-    // this.restrictions = (String) courseEntity.getProperty("restrictions");
-    // this.additionalInfo = (String) courseEntity.getProperty("additional_info");
-    // this.creditGrantedFor = (String) courseEntity.getProperty("credit_granted_for");
   }
 
   public Course(Entity courseEntity, ArrayList<EmbeddedEntity> sections) {}

--- a/src/main/java/com/google/collegeplanner/data/Course.java
+++ b/src/main/java/com/google/collegeplanner/data/Course.java
@@ -149,8 +149,6 @@ public class Course {
         (String) courseEntity.getProperty("credit_granted_for"));
   }
 
-  public Course(Entity courseEntity, ArrayList<EmbeddedEntity> sections) {}
-
   /*
    * Validates the courseId parameter that is passed into the constructors.
    */

--- a/src/main/java/com/google/collegeplanner/data/Meeting.java
+++ b/src/main/java/com/google/collegeplanner/data/Meeting.java
@@ -34,10 +34,12 @@ import org.json.simple.JSONObject;
  * discussion, are two separate meetings for the same class.
  */
 public class Meeting {
-  // days is for use on the back end.
+  // days is the list of DayOfWeek objects used for the algorithm. It's not in the format that we
+  // want to be serialized into json to get sent into the front end however. The 'transient' keyword
+  // keeps this variable from getting serialized by Gson.
   private transient ArrayList<DayOfWeek> days;
   // daysString gets serialized into json and is in the correct format to be rendered on the front
-  // end.
+  // end. It doesn't get used by the algorithm. Example, 'MThF'.
   @SerializedName("days") private String daysString;
   @SerializedName("room") private String room;
   @SerializedName("building") private String building;

--- a/src/main/java/com/google/collegeplanner/data/Meeting.java
+++ b/src/main/java/com/google/collegeplanner/data/Meeting.java
@@ -14,16 +14,18 @@
 
 package com.google.collegeplanner.data;
 
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.gson.annotations.SerializedName;
 import java.text.ParseException;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Collections;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import java.time.format.DateTimeParseException;
 
 /*
  * This Meeting class depicts a session a class takes place during. For example, a
@@ -32,15 +34,17 @@ import java.time.format.DateTimeParseException;
  * discussion, are two separate meetings for the same class.
  */
 public class Meeting {
-  private ArrayList<DayOfWeek> days;
-  private String room;
-  private String building;
-  private int startTime;
-  private int endTime;
+  private transient ArrayList<DayOfWeek> days;
+  @SerializedName("days") private String daysString;
+  @SerializedName("room") private String room;
+  @SerializedName("building") private String building;
+  @SerializedName("start_time") private int startTime;
+  @SerializedName("end_time") private int endTime;
 
   public Meeting(String days, String room, String building, int startTime, int endTime)
       throws ParseException {
     this.days = new ArrayList<DayOfWeek>();
+    this.daysString = days;
     this.room = room;
     this.building = building;
     this.startTime = startTime;
@@ -51,12 +55,24 @@ public class Meeting {
 
   public Meeting(JSONObject json) throws ParseException {
     this.days = new ArrayList<DayOfWeek>();
+    this.daysString = (String) json.get("days");
     this.startTime = parseTime((String) json.get("start_time"));
     this.endTime = parseTime((String) json.get("end_time"));
     this.room = (String) json.get("room");
     this.building = (String) json.get("building");
 
     assignDays((String) json.get("days"));
+  }
+
+  public Meeting(EmbeddedEntity meetingEntity) throws ParseException {
+    this.startTime = ((Long) meetingEntity.getProperty("start_time")).intValue();
+    this.endTime = ((Long) meetingEntity.getProperty("end_time")).intValue();
+    this.room = (String) meetingEntity.getProperty("room");
+    this.building = (String) meetingEntity.getProperty("building");
+
+    this.days = new ArrayList<DayOfWeek>();
+    this.daysString = (String) meetingEntity.getProperty("days");
+    assignDays((String) meetingEntity.getProperty("days"));
   }
 
   /**
@@ -162,6 +178,10 @@ public class Meeting {
 
   public int getEndTime() {
     return endTime;
+  }
+
+  public String getDaysString() {
+    return daysString;
   }
 
   @Override

--- a/src/main/java/com/google/collegeplanner/data/Meeting.java
+++ b/src/main/java/com/google/collegeplanner/data/Meeting.java
@@ -34,7 +34,9 @@ import org.json.simple.JSONObject;
  * discussion, are two separate meetings for the same class.
  */
 public class Meeting {
+  // days is for use on the back end.
   private transient ArrayList<DayOfWeek> days;
+  // daysString gets serialized into json and is in the correct format to be rendered on the front end.
   @SerializedName("days") private String daysString;
   @SerializedName("room") private String room;
   @SerializedName("building") private String building;
@@ -72,6 +74,7 @@ public class Meeting {
 
     this.days = new ArrayList<DayOfWeek>();
     this.daysString = (String) meetingEntity.getProperty("days");
+
     assignDays((String) meetingEntity.getProperty("days"));
   }
 

--- a/src/main/java/com/google/collegeplanner/data/Meeting.java
+++ b/src/main/java/com/google/collegeplanner/data/Meeting.java
@@ -36,7 +36,8 @@ import org.json.simple.JSONObject;
 public class Meeting {
   // days is for use on the back end.
   private transient ArrayList<DayOfWeek> days;
-  // daysString gets serialized into json and is in the correct format to be rendered on the front end.
+  // daysString gets serialized into json and is in the correct format to be rendered on the front
+  // end.
   @SerializedName("days") private String daysString;
   @SerializedName("room") private String room;
   @SerializedName("building") private String building;

--- a/src/main/java/com/google/collegeplanner/data/Section.java
+++ b/src/main/java/com/google/collegeplanner/data/Section.java
@@ -14,8 +14,13 @@
 
 package com.google.collegeplanner.data;
 
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.List;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
@@ -23,13 +28,13 @@ import org.json.simple.JSONObject;
  * This class represents a section of a course.
  */
 public class Section {
-  private String sectionId;
-  private String courseId;
-  private String waitlist;
-  private int openSeats;
-  private int seats;
-  private String[] instructors;
-  private Meeting[] meetings;
+  @SerializedName("section_id") private String sectionId;
+  @SerializedName("course_id") private String courseId;
+  @SerializedName("waitlist") private String waitlist;
+  @SerializedName("open_seats") private int openSeats;
+  @SerializedName("seats") private int seats;
+  @SerializedName("instructors") private String[] instructors;
+  @SerializedName("meetings") private Meeting[] meetings;
 
   public Section(String sectionId, String courseId, String waitlist, int openSeats, int seats,
       String[] instructors, Meeting[] meetings) throws ParseException {
@@ -59,6 +64,7 @@ public class Section {
 
     this.sectionId = (String) json.get("section_id");
     this.waitlist = (String) json.get("waitlist");
+    this.courseId = (String) json.get("course");
 
     JSONArray instructorsArray = (JSONArray) json.get("instructors");
     ArrayList<String> instructors = new ArrayList<String>();
@@ -77,6 +83,49 @@ public class Section {
     this.meetings = meetings.toArray(new Meeting[0]);
 
     validate();
+  }
+
+  public Section(EmbeddedEntity sectionEntity) throws ParseException {
+    // this(
+    //   sectionEntity.getProperty("section_id"),
+    //   sectionEntity.getProperty("course_id"),
+    //   sectionEntity.getProperty("waitlist"),
+    //   sectionEntity.getProperty("open_seats"),
+    //   sectionEntity.getProperty("seats"),
+    //   sectionEntity.getProperty("instructors"),
+    // )
+    this.sectionId = (String) sectionEntity.getProperty("section_id");
+    this.courseId = (String) sectionEntity.getProperty("course_id");
+    this.waitlist = (String) sectionEntity.getProperty("waitlist");
+    // try {
+    //   this.openSeats = Integer.parseInt((String) sectionEntity.getProperty("open_seats"));
+    // } catch (NumberFormatException e) {
+    //   this.openSeats = 0;
+    // }
+
+    this.seats = ((Long) sectionEntity.getProperty("seats")).intValue();
+    this.openSeats = ((Long) sectionEntity.getProperty("open_seats")).intValue();
+    // try {
+    //   this.seats = Integer.parseInt((String) sectionEntity.getProperty("seats"));
+    // } catch (NumberFormatException e) {
+    //   this.seats = 0;
+    // }
+
+    // List<String> instructors = sectionEntity.getProperty("instructors")
+    ArrayList<String> instructorsProp =
+        (ArrayList<String>) sectionEntity.getProperty("instructors");
+    this.instructors = instructorsProp.toArray(new String[0]);
+
+    ArrayList<EmbeddedEntity> meetingEntities =
+        (ArrayList<EmbeddedEntity>) sectionEntity.getProperty("meetings");
+    System.out.println(meetingEntities.size());
+    ArrayList<Meeting> meetings = new ArrayList<Meeting>();
+    for (EmbeddedEntity meetingEntity : meetingEntities) {
+      System.out.println("MEETING");
+      Meeting meeting = new Meeting(meetingEntity);
+      meetings.add(meeting);
+    }
+    this.meetings = meetings.toArray(new Meeting[0]);
   }
 
   /*

--- a/src/main/java/com/google/collegeplanner/data/Section.java
+++ b/src/main/java/com/google/collegeplanner/data/Section.java
@@ -96,7 +96,6 @@ public class Section {
         (ArrayList<EmbeddedEntity>) sectionEntity.getProperty("meetings");
     ArrayList<Meeting> meetings = new ArrayList<Meeting>();
     for (EmbeddedEntity meetingEntity : meetingEntities) {
-      System.out.println("MEETING");
       Meeting meeting = new Meeting(meetingEntity);
       meetings.add(meeting);
     }

--- a/src/main/java/com/google/collegeplanner/data/Section.java
+++ b/src/main/java/com/google/collegeplanner/data/Section.java
@@ -15,12 +15,9 @@
 package com.google.collegeplanner.data;
 
 import com.google.appengine.api.datastore.EmbeddedEntity;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.List;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
@@ -86,39 +83,17 @@ public class Section {
   }
 
   public Section(EmbeddedEntity sectionEntity) throws ParseException {
-    // this(
-    //   sectionEntity.getProperty("section_id"),
-    //   sectionEntity.getProperty("course_id"),
-    //   sectionEntity.getProperty("waitlist"),
-    //   sectionEntity.getProperty("open_seats"),
-    //   sectionEntity.getProperty("seats"),
-    //   sectionEntity.getProperty("instructors"),
-    // )
     this.sectionId = (String) sectionEntity.getProperty("section_id");
     this.courseId = (String) sectionEntity.getProperty("course_id");
     this.waitlist = (String) sectionEntity.getProperty("waitlist");
-    // try {
-    //   this.openSeats = Integer.parseInt((String) sectionEntity.getProperty("open_seats"));
-    // } catch (NumberFormatException e) {
-    //   this.openSeats = 0;
-    // }
-
     this.seats = ((Long) sectionEntity.getProperty("seats")).intValue();
     this.openSeats = ((Long) sectionEntity.getProperty("open_seats")).intValue();
-    // try {
-    //   this.seats = Integer.parseInt((String) sectionEntity.getProperty("seats"));
-    // } catch (NumberFormatException e) {
-    //   this.seats = 0;
-    // }
-
-    // List<String> instructors = sectionEntity.getProperty("instructors")
     ArrayList<String> instructorsProp =
         (ArrayList<String>) sectionEntity.getProperty("instructors");
     this.instructors = instructorsProp.toArray(new String[0]);
 
     ArrayList<EmbeddedEntity> meetingEntities =
         (ArrayList<EmbeddedEntity>) sectionEntity.getProperty("meetings");
-    System.out.println(meetingEntities.size());
     ArrayList<Meeting> meetings = new ArrayList<Meeting>();
     for (EmbeddedEntity meetingEntity : meetingEntities) {
       System.out.println("MEETING");

--- a/src/main/java/com/google/collegeplanner/servlets/CourseListServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/CourseListServlet.java
@@ -77,7 +77,7 @@ public class CourseListServlet extends BaseServlet {
       try {
         course = new Course(courseEntity);
       } catch (ParseException e) {
-        respondWithError(HttpServletResponse.SC_BAD_REQUEST, response);
+        respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
         return;
       }
       courses.add(course);

--- a/src/main/java/com/google/collegeplanner/servlets/CourseListServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/CourseListServlet.java
@@ -50,7 +50,6 @@ public class CourseListServlet extends BaseServlet {
   }
 
   public CourseListServlet(DatastoreService datastore) {
-    // super(apiUtil);
     this.datastore = datastore;
   }
 
@@ -83,23 +82,6 @@ public class CourseListServlet extends BaseServlet {
       }
       courses.add(course);
     }
-
-    // URI uri;
-    // try {
-    //   URIBuilder builder = new URIBuilder("https://api.umd.io/v1/courses");
-    //   builder.setParameter("semester", "202008");
-    //   builder.setParameter("dept_id", department);
-    //   uri = builder.build();
-    // } catch (URISyntaxException e) {
-    //   respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
-    //   return;
-    // }
-
-    // JSONArray jsonArray = apiUtil.getJsonArray(uri);
-    // if (jsonArray == null) {
-    //   respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
-    //   return;
-    // }
 
     JSONObject schoolCourseInfo = new JSONObject();
     schoolCourseInfo.put("courses", courses);

--- a/src/main/java/com/google/collegeplanner/servlets/DatastoreServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/DatastoreServlet.java
@@ -194,7 +194,7 @@ public class DatastoreServlet extends BaseServlet {
     courseEntity.setProperty("name", course.getName());
     courseEntity.setProperty("semester", course.getSemester());
     courseEntity.setProperty("credits", course.getCredits());
-    courseEntity.setProperty("department_id", course.getDepartmentId());
+    courseEntity.setProperty("dept_id", course.getDepartmentId());
     courseEntity.setProperty("description", course.getDescription());
     courseEntity.setProperty("coreqs", course.getCorequisites());
     courseEntity.setProperty("prereqs", course.getCorequisites());

--- a/src/main/java/com/google/collegeplanner/servlets/SectionServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/SectionServlet.java
@@ -49,7 +49,6 @@ public class SectionServlet extends BaseServlet {
   }
 
   public SectionServlet(DatastoreService datastore) {
-    // super(apiUtil);
     this.datastore = datastore;
   }
 

--- a/src/main/java/com/google/collegeplanner/servlets/SectionServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/SectionServlet.java
@@ -71,65 +71,34 @@ public class SectionServlet extends BaseServlet {
       return;
     }
 
-    // Filter filter = new CompositeFilter(CompositeFilterOperator.AND, Arrays.asList(
-    //  new FilterPredicate("a", FilterOperator.EQUAL, 1),
-    //  new CompositeFilter(CompositeFilterOperator.OR, Arrays.<Filter>asList(
-    //      new FilterPredicate("b", FilterOperator.EQUAL, 2),
-    //      new FilterPredicate("c", FilterOperator.EQUAL, 3)))));
-
-    System.out.println("BEFORE QUERY");
     Query query = new Query("Course").setFilter(
         new FilterPredicate("course_id", FilterOperator.EQUAL, courseId));
     PreparedQuery preparedQuery = datastore.prepare(query);
     List<Entity> results = preparedQuery.asList(FetchOptions.Builder.withDefaults());
 
     if (results.size() == 0) {
-      System.out.println("Empty query results");
       respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
       return;
     }
 
-    System.out.println("BEFORE FINDING SECTION");
-
+    // Convert Section entities to Section objects to serialize into json.
+    ArrayList<Section> sections = new ArrayList<Section>();
     Entity courseEntity = results.get(0);
     ArrayList<EmbeddedEntity> sectionEntities =
         (ArrayList<EmbeddedEntity>) courseEntity.getProperty("sections");
-    ArrayList<Section> sections = new ArrayList<Section>();
     for (EmbeddedEntity sectionEntity : sectionEntities) {
-      System.out.println("SECTION");
       String section_id = (String) sectionEntity.getProperty("section_id");
-      System.out.println(section_id);
-      System.out.println(sectionId);
       if (section_id.equals(sectionId)) {
-        System.out.println("FOUND");
         Section section;
         try {
           section = new Section(sectionEntity);
         } catch (ParseException e) {
-          System.out.println("PARSE EXCEPTION");
-          System.out.println(e.getMessage());
           respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
           return;
         }
         sections.add(section);
-      } else {
-        System.out.println("not found");
       }
     }
-
-    // URI uri;
-    // try {
-    //   uri = new URI("https://api.umd.io/v1/courses/" + courseId + "/sections/" + sectionId);
-    // } catch (URISyntaxException e) {
-    //   respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
-    //   return;
-    // }
-
-    // JSONArray jsonArray = apiUtil.getJsonArray(uri);
-    // if (jsonArray == null) {
-    //   respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
-    //   return;
-    // }
 
     JSONObject sectionsInfo = new JSONObject();
     sectionsInfo.put("sections", sections);

--- a/src/main/java/com/google/collegeplanner/servlets/SectionServlet.java
+++ b/src/main/java/com/google/collegeplanner/servlets/SectionServlet.java
@@ -77,7 +77,7 @@ public class SectionServlet extends BaseServlet {
     List<Entity> results = preparedQuery.asList(FetchOptions.Builder.withDefaults());
 
     if (results.size() == 0) {
-      respondWithError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response);
+      respondWithError(HttpServletResponse.SC_NOT_FOUND, response);
       return;
     }
 

--- a/src/main/webapp/js/lib/calendar.js
+++ b/src/main/webapp/js/lib/calendar.js
@@ -119,9 +119,11 @@ async function addCourse(course, section) {
   if (course == null || section == null) {
     return;
   }
+  console.log('addCourse in calendar.js');
+  console.log(section);
   const response = await fetch(`/api/sections?course_id=${
-      encodeURIComponent(course.course_id)}&section_id=${
-      encodeURIComponent(section.substr(section.length - 4))}`);
+      encodeURIComponent(
+          course.course_id)}&section_id=${encodeURIComponent(section)}`);
   const json = await response.json();
   if (json.sections == null) {
     return;

--- a/src/main/webapp/js/lib/calendar.js
+++ b/src/main/webapp/js/lib/calendar.js
@@ -119,8 +119,6 @@ async function addCourse(course, section) {
   if (course == null || section == null) {
     return;
   }
-  console.log('addCourse in calendar.js');
-  console.log(section);
   const response = await fetch(`/api/sections?course_id=${
       encodeURIComponent(
           course.course_id)}&section_id=${encodeURIComponent(section)}`);

--- a/src/test/java/com/google/collegeplanner/CourseListServletTest.java
+++ b/src/test/java/com/google/collegeplanner/CourseListServletTest.java
@@ -217,7 +217,6 @@ public final class CourseListServletTest {
     firstCoursesJson = (JSONArray) parser.parse(firstCourses);
     firstCourseJson = (JSONArray) parser.parse(firstCourse);
     firstSectionJson = (JSONArray) parser.parse(firstSection);
-    // secondCourseJson = (JSONArray) parser.parse(secondCourse);
     secondSectionJson = (JSONArray) parser.parse(secondSection);
     emptyJson = (JSONArray) parser.parse("[]");
 

--- a/src/test/java/com/google/collegeplanner/CourseListServletTest.java
+++ b/src/test/java/com/google/collegeplanner/CourseListServletTest.java
@@ -214,6 +214,7 @@ public final class CourseListServletTest {
     when(mockedResponse.getWriter()).thenReturn(writer);
     datastore = DatastoreServiceFactory.getDatastoreService();
     apiUtil = mock(ApiUtil.class);
+    when(mockedRequest.getParameter("department")).thenReturn("AASP");
 
     firstCoursesJson = (JSONArray) parser.parse(firstCourses);
     firstCourseJson = (JSONArray) parser.parse(firstCourse);
@@ -222,7 +223,7 @@ public final class CourseListServletTest {
     secondSectionJson = (JSONArray) parser.parse(secondSection);
     emptyJson = (JSONArray) parser.parse("[]");
 
-    when(mockedRequest.getParameter("department")).thenReturn("AASP");
+    
 
     helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
     helper.setUp();
@@ -250,6 +251,8 @@ public final class CourseListServletTest {
         + "\"dept_id\":\"AASP\","
         + "\"sections\":null"
         + "}]";
+
+        
 
     // Add course to datastore.
     when(apiUtil.getJsonArray(any(URI.class)))
@@ -327,18 +330,18 @@ public final class CourseListServletTest {
         expectedJsonResponse, coursesDetailed.toString(), JSONCompareMode.STRICT);
   }
 
-  // @Test
-  // public void returnsErrorJson() throws Exception {
-  //   ApiUtil apiUtil = mock(ApiUtil.class);
-  //   when(apiUtil.getJsonArray(any(URI.class))).thenReturn(null);
-  //   CourseListServlet servlet = new CourseListServlet(datastore, apiUtil);
-  //   servlet.doGet(mockedRequest, mockedResponse);
-  //   // Verifies whether status was set to SC_INTERNAL_SERVER_ERROR
-  //   verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-  //   verify(mockedResponse, never())
-  //       .setStatus(not(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)));
-  //   JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
-  //   String expectedJson = "{\"message\":\"Internal server error.\",\"status\":\"error\"}";
-  //   JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);
-  // }
+  @Test
+  public void returnsError400() throws Exception {
+    ApiUtil apiUtil = mock(ApiUtil.class);
+    when(mockedRequest.getParameter("department")).thenReturn(null);
+    CourseListServlet servlet = new CourseListServlet(datastore);
+    servlet.doGet(mockedRequest, mockedResponse);
+    // Verifies whether status was set to SC_BAD_REQUEST
+    verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    verify(mockedResponse, never())
+        .setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
+    JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
+    String expectedJson = "{\"message\":\"Invalid or missing department.\",\"status\":\"error\"}";
+    JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);
+  }
 }

--- a/src/test/java/com/google/collegeplanner/CourseListServletTest.java
+++ b/src/test/java/com/google/collegeplanner/CourseListServletTest.java
@@ -223,8 +223,6 @@ public final class CourseListServletTest {
     secondSectionJson = (JSONArray) parser.parse(secondSection);
     emptyJson = (JSONArray) parser.parse("[]");
 
-    
-
     helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
     helper.setUp();
   }
@@ -251,8 +249,6 @@ public final class CourseListServletTest {
         + "\"dept_id\":\"AASP\","
         + "\"sections\":null"
         + "}]";
-
-        
 
     // Add course to datastore.
     when(apiUtil.getJsonArray(any(URI.class)))
@@ -338,8 +334,7 @@ public final class CourseListServletTest {
     servlet.doGet(mockedRequest, mockedResponse);
     // Verifies whether status was set to SC_BAD_REQUEST
     verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_BAD_REQUEST);
-    verify(mockedResponse, never())
-        .setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
+    verify(mockedResponse, never()).setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
     JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
     String expectedJson = "{\"message\":\"Invalid or missing department.\",\"status\":\"error\"}";
     JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);

--- a/src/test/java/com/google/collegeplanner/CourseListServletTest.java
+++ b/src/test/java/com/google/collegeplanner/CourseListServletTest.java
@@ -22,8 +22,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.collegeplanner.servlets.ApiUtil;
 import com.google.collegeplanner.servlets.CourseListServlet;
+import com.google.collegeplanner.servlets.DatastoreServlet;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
@@ -50,118 +57,288 @@ public final class CourseListServletTest {
   StringWriter stringWriter;
   PrintWriter writer;
   JSONParser parser;
+  DatastoreService datastore;
+  LocalServiceTestHelper helper;
+  ApiUtil apiUtil;
+
+  JSONArray firstCoursesJson;
+  JSONArray firstCourseJson;
+  JSONArray firstSectionJson;
+  JSONArray secondSectionJson;
+  JSONArray emptyJson;
+
+  String firstCourses = "[{"
+      + "\"course_id\":\"AASP100\","
+      + "\"core\":[\"SH\",\"D\"],"
+      + "\"relationships\":{"
+      + "  \"coreqs\":null,"
+      + "  \"additional_info\":null,"
+      + "  \"restrictions\":null,"
+      + "  \"credit_granted_for\":null,"
+      + "  \"also_offered_as\":null,"
+      + "  \"formerly\":null,"
+      + "  \"prereqs\":null"
+      + "},"
+      + "\"credits\":\"3\","
+      + "\"name\":\"Introduction to African American Studies\","
+      + "\"description\":\"Significant aspects of the history of African Americans.\","
+      + "\"semester\":\"202008\","
+      + "\"gen_ed\":[[\"DSHS\",\"DVUP\"]],"
+      + "\"dept_id\":\"AASP\","
+      + "\"department\":\"African American Studies\","
+      + "\"grading_method\":[\"Regular\",\"Pass-Fail\",\"Audit\"],"
+      + "\"sections\":["
+      + "  \"AASP100-0101\","
+      + "  \"AASP100-0201\","
+      + "  \"AASP100-0301\","
+      + "  \"AASP100-0401\","
+      + "  \"AASP100-0501\","
+      + "  \"AASP100-0601\","
+      + "  \"AASP100-0701\""
+      + "]"
+      + "},{"
+      + "\"course_id\":\"AASP100H\","
+      + "\"core\":[\"SH\",\"D\"],"
+      + "\"relationships\":{"
+      + "  \"coreqs\":null,"
+      + "  \"additional_info\":null,"
+      + "  \"restrictions\":null,"
+      + "  \"credit_granted_for\":null,"
+      + "  \"also_offered_as\":null,"
+      + "  \"formerly\":null,"
+      + "  \"prereqs\":null"
+      + "},"
+      + "\"credits\":\"3\","
+      + "\"name\":\"Introduction to African American Studies\","
+      + "\"description\":\"Significant aspects of the history of African Americans.\","
+      + "\"semester\":\"202008\","
+      + "\"gen_ed\":[[\"DSHS\",\"DVUP\"]],"
+      + "\"dept_id\":\"AASP\","
+      + "\"department\":\"African American Studies\","
+      + "\"grading_method\":[\"Regular\",\"Pass-Fail\",\"Audit\"],"
+      + "\"sections\":["
+      + "  \"AASP100H-0101\""
+      + "]"
+      + "}]";
+
+  String firstCourse = "[{"
+      + "\"course_id\":\"AASP100\","
+      + "\"core\":[\"SH\",\"D\"],"
+      + "\"relationships\":{"
+      + "  \"coreqs\":null,"
+      + "  \"additional_info\":null,"
+      + "  \"restrictions\":null,"
+      + "  \"credit_granted_for\":null,"
+      + "  \"also_offered_as\":null,"
+      + "  \"formerly\":null,"
+      + "  \"prereqs\":null"
+      + "},"
+      + "\"credits\":\"3\","
+      + "\"name\":\"Introduction to African American Studies\","
+      + "\"description\":\"Significant aspects of the history of African Americans.\","
+      + "\"semester\":\"202008\","
+      + "\"gen_ed\":[[\"DSHS\",\"DVUP\"]],"
+      + "\"dept_id\":\"AASP\","
+      + "\"department\":\"African American Studies\","
+      + "\"grading_method\":[\"Regular\",\"Pass-Fail\",\"Audit\"],"
+      + "\"sections\":["
+      + "  \"AASP100-0101\","
+      + "  \"AASP100-0201\","
+      + "  \"AASP100-0301\","
+      + "  \"AASP100-0401\","
+      + "  \"AASP100-0501\","
+      + "  \"AASP100-0601\","
+      + "  \"AASP100-0701\""
+      + "]"
+      + "}]";
+
+  String firstSection = "[{"
+      + "\"course\": \"AASP100\","
+      + "\"section_id\": \"AASP100-0101\","
+      + "\"semester\": \"202008\","
+      + "\"number\": \"0101\","
+      + "\"seats\": \"21\","
+      + "\"meetings\": [{"
+      + "  \"days\": \"MWF\","
+      + "  \"room\": \"1101\","
+      + "  \"building\": \"SQH\","
+      + "  \"classtype\": \"\","
+      + "  \"start_time\": \"10:00am\","
+      + "  \"end_time\": \"10:50am\""
+      + "}, {"
+      + "  \"days\": \"MWF\","
+      + "  \"room\": \"2205\","
+      + "  \"building\": \"LEF\","
+      + "  \"classtype\": \"\","
+      + "  \"start_time\": \"10:00am\","
+      + "  \"end_time\": \"10:50am\""
+      + "}],"
+      + "\"open_seats\": \"8\","
+      + "\"waitlist\": \"01\","
+      + "\"instructors\": [\"Shane Walsh\"]"
+      + "}]";
+
+  String secondSection = "[{"
+      + "\"course\": \"AAST200\","
+      + "\"section_id\": \"AAST200-0101\","
+      + "\"semester\": \"202008\","
+      + "\"number\": \"0101\","
+      + "\"seats\": \"40\","
+      + "\"meetings\": [{"
+      + "  \"days\": \"TuTh\","
+      + "  \"room\": \"1103\","
+      + "  \"building\": \"SQH\","
+      + "  \"classtype\": \"\","
+      + "  \"start_time\": \"3:30pm\","
+      + "  \"end_time\": \"4:45pm\""
+      + "}, {"
+      + "  \"days\": \"TuTh\","
+      + "  \"room\": \"ONLINE\","
+      + "  \"building\": \"\","
+      + "  \"classtype\": \"\","
+      + "  \"start_time\": \"3:30pm\","
+      + "  \"end_time\": \"4:45pm\""
+      + "}],"
+      + "\"open_seats\": \"0\","
+      + "\"waitlist\": \"80\","
+      + "\"instructors\": [\"Terry Park\"]"
+      + "}]";
 
   @Before
   public void before() throws Exception {
+    mockedRequest = mock(HttpServletRequest.class);
     mockedResponse = mock(HttpServletResponse.class);
     stringWriter = new StringWriter();
     writer = new PrintWriter(stringWriter);
     parser = new JSONParser();
     when(mockedResponse.getWriter()).thenReturn(writer);
+    datastore = DatastoreServiceFactory.getDatastoreService();
+    apiUtil = mock(ApiUtil.class);
 
-    mockedRequest = mock(HttpServletRequest.class);
+    firstCoursesJson = (JSONArray) parser.parse(firstCourses);
+    firstCourseJson = (JSONArray) parser.parse(firstCourse);
+    firstSectionJson = (JSONArray) parser.parse(firstSection);
+    // secondCourseJson = (JSONArray) parser.parse(secondCourse);
+    secondSectionJson = (JSONArray) parser.parse(secondSection);
+    emptyJson = (JSONArray) parser.parse("[]");
+
     when(mockedRequest.getParameter("department")).thenReturn("AASP");
+
+    helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+    helper.setUp();
   }
 
   @After
   public void after() {
     writer.flush();
+    helper.tearDown();
   }
 
   @Test
-  public void servletResponseHasCourses() throws Exception {
-    String expectedJson = "[{"
+  public void servletResponseHasCourse() throws Exception {
+    String expectedJsonResponse = "[{"
         + "\"course_id\":\"AASP100\","
-        + "\"core\":[\"SH\",\"D\"],"
-        + "\"relationships\":{"
-        + "  \"coreqs\":null,"
-        + "  \"additional_info\":null,"
-        + "  \"restrictions\":null,"
-        + "  \"credit_granted_for\":null,"
-        + "  \"also_offered_as\":null,"
-        + "  \"formerly\":null,"
-        + "  \"prereqs\":null"
-        + "},"
-        + "\"credits\":\"3\","
+        + "\"coreqs\":null,"
+        + "\"additional_info\":null,"
+        + "\"restrictions\":null,"
+        + "\"credit_granted_for\":null,"
+        + "\"prereqs\":null,"
+        + "\"credits\":3,"
         + "\"name\":\"Introduction to African American Studies\","
-        + "\"description\":\"Significant aspects of the history of African Americans "
-        + "with particular emphasis on the evolution and development of black communities "
-        + "from slavery to the present. Interdisciplinary introduction to social, "
-        + "political, legal and economic roots of contemporary problems faced by blacks "
-        + "in the United States with applications to the lives of other racial and ethnic "
-        + "minorities in the Americas and in other societies.\","
+        + "\"description\":\"Significant aspects of the history of African Americans.\","
         + "\"semester\":\"202008\","
-        + "\"gen_ed\":[[\"DSHS\",\"DVUP\"]],"
         + "\"dept_id\":\"AASP\","
-        + "\"department\":\"African American Studies\","
-        + "\"grading_method\":[\"Regular\",\"Pass-Fail\",\"Audit\"],"
-        + "\"sections\":["
-        + "  \"AASP100-0101\","
-        + "  \"AASP100-0201\","
-        + "  \"AASP100-0301\","
-        + "  \"AASP100-0401\","
-        + "  \"AASP100-0501\","
-        + "  \"AASP100-0601\","
-        + "  \"AASP100-0701\""
-        + "]"
-        + "},{"
-        + "\"course_id\":\"AASP100H\","
-        + "\"core\":[\"SH\",\"D\"],"
-        + "\"relationships\":{"
-        + "  \"coreqs\":null,"
-        + "  \"additional_info\":null,"
-        + "  \"restrictions\":null,"
-        + "  \"credit_granted_for\":null,"
-        + "  \"also_offered_as\":null,"
-        + "  \"formerly\":null,"
-        + "  \"prereqs\":null"
-        + "},"
-        + "\"credits\":\"3\","
-        + "\"name\":\"Introduction to African American Studies\","
-        + "\"description\":\"Significant aspects of the history of African Americans "
-        + "with particular emphasis on the evolution and development of black communities "
-        + "from slavery to the present. Interdisciplinary introduction to social, "
-        + "political, legal and economic roots of contemporary problems faced by blacks "
-        + "in the United States with applications to the lives of other racial and ethnic "
-        + "minorities in the Americas and in other societies.\","
-        + "\"semester\":\"202008\","
-        + "\"gen_ed\":[[\"DSHS\",\"DVUP\"]],"
-        + "\"dept_id\":\"AASP\","
-        + "\"department\":\"African American Studies\","
-        + "\"grading_method\":[\"Regular\",\"Pass-Fail\",\"Audit\"],"
-        + "\"sections\":["
-        + "  \"AASP100H-0101\""
-        + "]"
+        + "\"sections\":null"
         + "}]";
-    JSONArray courses = (JSONArray) parser.parse(expectedJson);
-    ApiUtil mockedApiUtil = mock(ApiUtil.class);
-    when(mockedApiUtil.getJsonArray(any(URI.class))).thenReturn(courses);
-    CourseListServlet servlet = new CourseListServlet(mockedApiUtil);
-    servlet.doGet(mockedRequest, mockedResponse);
 
+    // Add course to datastore.
+    when(apiUtil.getJsonArray(any(URI.class)))
+        .thenReturn(firstCourseJson, firstSectionJson, emptyJson);
+    DatastoreServlet datastoreServlet = new DatastoreServlet(datastore, apiUtil);
+    datastoreServlet.doPost(null, mockedResponse);
+
+    CourseListServlet servlet = new CourseListServlet(datastore);
+    servlet.doGet(mockedRequest, mockedResponse);
     JSONObject responseObj = (JSONObject) parser.parse(stringWriter.toString());
     JSONArray coursesDetailed = (JSONArray) responseObj.get("courses");
+
+    // Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+    // System.out.println(gson.toJson(coursesDetailed));
 
     // Tests that response[courses] exists
     Assert.assertNotNull(coursesDetailed);
     // Checks that the correct number of JSON Objects are contained
-    Assert.assertEquals(coursesDetailed.size(), 2);
+    Assert.assertEquals(1, coursesDetailed.size());
     // Checks whether output is correct
-    JSONAssert.assertEquals(expectedJson, coursesDetailed.toString(), JSONCompareMode.STRICT);
+    JSONAssert.assertEquals(
+        expectedJsonResponse, coursesDetailed.toString(), JSONCompareMode.STRICT);
   }
 
   @Test
-  public void returnsErrorJson() throws Exception {
-    ApiUtil apiUtil = mock(ApiUtil.class);
-    when(apiUtil.getJsonArray(any(URI.class))).thenReturn(null);
-    CourseListServlet servlet = new CourseListServlet(apiUtil);
+  public void servletResponseHasCourses() throws Exception {
+    String expectedJsonResponse = "[{"
+        + "\"course_id\":\"AASP100\","
+        + "\"coreqs\":null,"
+        + "\"additional_info\":null,"
+        + "\"restrictions\":null,"
+        + "\"credit_granted_for\":null,"
+        + "\"prereqs\":null,"
+        + "\"credits\":3,"
+        + "\"name\":\"Introduction to African American Studies\","
+        + "\"description\":\"Significant aspects of the history of African Americans.\","
+        + "\"semester\":\"202008\","
+        + "\"dept_id\":\"AASP\","
+        + "\"sections\":null"
+        + "},{"
+        + "\"course_id\":\"AASP100H\","
+        + "\"coreqs\":null,"
+        + "\"additional_info\":null,"
+        + "\"restrictions\":null,"
+        + "\"credit_granted_for\":null,"
+        + "\"prereqs\":null,"
+        + "\"credits\":3,"
+        + "\"name\":\"Introduction to African American Studies\","
+        + "\"description\":\"Significant aspects of the history of African Americans.\","
+        + "\"semester\":\"202008\","
+        + "\"dept_id\":\"AASP\","
+        + "\"sections\":null"
+        + "}]";
+
+    // Add course to datastore.
+    when(apiUtil.getJsonArray(any(URI.class)))
+        .thenReturn(firstCoursesJson, firstSectionJson, secondSectionJson, emptyJson);
+    DatastoreServlet datastoreServlet = new DatastoreServlet(datastore, apiUtil);
+    datastoreServlet.doPost(null, mockedResponse);
+
+    CourseListServlet servlet = new CourseListServlet(datastore);
     servlet.doGet(mockedRequest, mockedResponse);
-    // Verifies whether status was set to SC_INTERNAL_SERVER_ERROR
-    verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    verify(mockedResponse, never())
-        .setStatus(not(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)));
-    JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
-    String expectedJson = "{\"message\":\"Internal server error.\",\"status\":\"error\"}";
-    JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);
+    JSONObject responseObj = (JSONObject) parser.parse(stringWriter.toString());
+    JSONArray coursesDetailed = (JSONArray) responseObj.get("courses");
+
+    // Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+    // System.out.println(gson.toJson(coursesDetailed));
+
+    // Tests that response[courses] exists
+    Assert.assertNotNull(coursesDetailed);
+    // Checks that the correct number of JSON Objects are contained
+    Assert.assertEquals(2, coursesDetailed.size());
+    // Checks whether output is correct
+    JSONAssert.assertEquals(
+        expectedJsonResponse, coursesDetailed.toString(), JSONCompareMode.STRICT);
   }
+
+  // @Test
+  // public void returnsErrorJson() throws Exception {
+  //   ApiUtil apiUtil = mock(ApiUtil.class);
+  //   when(apiUtil.getJsonArray(any(URI.class))).thenReturn(null);
+  //   CourseListServlet servlet = new CourseListServlet(datastore, apiUtil);
+  //   servlet.doGet(mockedRequest, mockedResponse);
+  //   // Verifies whether status was set to SC_INTERNAL_SERVER_ERROR
+  //   verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+  //   verify(mockedResponse, never())
+  //       .setStatus(not(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)));
+  //   JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
+  //   String expectedJson = "{\"message\":\"Internal server error.\",\"status\":\"error\"}";
+  //   JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);
+  // }
 }

--- a/src/test/java/com/google/collegeplanner/CourseListServletTest.java
+++ b/src/test/java/com/google/collegeplanner/CourseListServletTest.java
@@ -261,9 +261,6 @@ public final class CourseListServletTest {
     JSONObject responseObj = (JSONObject) parser.parse(stringWriter.toString());
     JSONArray coursesDetailed = (JSONArray) responseObj.get("courses");
 
-    // Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
-    // System.out.println(gson.toJson(coursesDetailed));
-
     // Tests that response[courses] exists
     Assert.assertNotNull(coursesDetailed);
     // Checks that the correct number of JSON Objects are contained
@@ -313,9 +310,6 @@ public final class CourseListServletTest {
     servlet.doGet(mockedRequest, mockedResponse);
     JSONObject responseObj = (JSONObject) parser.parse(stringWriter.toString());
     JSONArray coursesDetailed = (JSONArray) responseObj.get("courses");
-
-    // Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
-    // System.out.println(gson.toJson(coursesDetailed));
 
     // Tests that response[courses] exists
     Assert.assertNotNull(coursesDetailed);

--- a/src/test/java/com/google/collegeplanner/CourseListServletTest.java
+++ b/src/test/java/com/google/collegeplanner/CourseListServletTest.java
@@ -29,8 +29,6 @@ import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.collegeplanner.servlets.ApiUtil;
 import com.google.collegeplanner.servlets.CourseListServlet;
 import com.google.collegeplanner.servlets.DatastoreServlet;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;

--- a/src/test/java/com/google/collegeplanner/SectionTest.java
+++ b/src/test/java/com/google/collegeplanner/SectionTest.java
@@ -251,11 +251,6 @@ public final class SectionTest {
     JSONObject responseObj = (JSONObject) parser.parse(stringWriter.toString());
     JSONArray sections = (JSONArray) responseObj.get("sections");
 
-    // Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
-    // System.out.println(gson.toJson(sections));
-    // JSONArray expected = (JSONArray) parser.parse(expectedJson);
-    // System.out.println(gson.toJson(expected));
-
     // Tests that response["sections"] exists
     Assert.assertNotNull(sections);
     // Checks that the correct number of JSON Objects are contained
@@ -264,19 +259,30 @@ public final class SectionTest {
     JSONAssert.assertEquals(expectedJson, sections.toString(), JSONCompareMode.STRICT);
   }
 
-  // @Test
-  // public void returnsErrorJson() throws Exception {
-  //   ApiUtil apiUtil = mock(ApiUtil.class);
-  //   when(apiUtil.getJsonArray(any(URI.class))).thenReturn(null);
-  //   SectionServlet servlet = new SectionServlet(apiUtil);
-  //   servlet.doGet(mockedRequest, mockedResponse);
-  //   // Verifies whether status was set to SC_INTERNAL_SERVER_ERROR
-  //   verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-  //   verify(mockedResponse, never())
-  //       .setStatus(not(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)));
-  //   JSONParser parser = new JSONParser();
-  //   JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
-  //   String expectedJson = "{\"message\":\"Internal server error.\",\"status\":\"error\"}";
-  //   JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);
-  // }
+  @Test
+  public void returnsError400() throws Exception {
+    when(mockedRequest.getParameter("course_id")).thenReturn(null);
+    SectionServlet servlet = new SectionServlet(datastore);
+    servlet.doGet(mockedRequest, mockedResponse);
+    // Verifies whether status was set to SC_BAD_REQUEST
+    verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    verify(mockedResponse, never())
+        .setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
+    JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
+    String expectedJson = "{\"message\":\"Invalid or missing course id.\",\"status\":\"error\"}";
+    JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);
+  }
+
+  @Test
+  public void returnsError404() throws Exception {
+    SectionServlet servlet = new SectionServlet(datastore);
+    servlet.doGet(mockedRequest, mockedResponse);
+    // Verifies whether status was set to SC_NOT_FOUND when the query returns no results
+    verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_NOT_FOUND);
+    verify(mockedResponse, never())
+        .setStatus(not(eq(HttpServletResponse.SC_NOT_FOUND)));
+    JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
+    String expectedJson = "{\"message\":\"Not found.\",\"status\":\"error\"}";
+    JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);
+  }
 }

--- a/src/test/java/com/google/collegeplanner/SectionTest.java
+++ b/src/test/java/com/google/collegeplanner/SectionTest.java
@@ -266,8 +266,7 @@ public final class SectionTest {
     servlet.doGet(mockedRequest, mockedResponse);
     // Verifies whether status was set to SC_BAD_REQUEST
     verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_BAD_REQUEST);
-    verify(mockedResponse, never())
-        .setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
+    verify(mockedResponse, never()).setStatus(not(eq(HttpServletResponse.SC_BAD_REQUEST)));
     JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
     String expectedJson = "{\"message\":\"Invalid or missing course id.\",\"status\":\"error\"}";
     JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);
@@ -279,8 +278,7 @@ public final class SectionTest {
     servlet.doGet(mockedRequest, mockedResponse);
     // Verifies whether status was set to SC_NOT_FOUND when the query returns no results
     verify(mockedResponse, times(1)).setStatus(HttpServletResponse.SC_NOT_FOUND);
-    verify(mockedResponse, never())
-        .setStatus(not(eq(HttpServletResponse.SC_NOT_FOUND)));
+    verify(mockedResponse, never()).setStatus(not(eq(HttpServletResponse.SC_NOT_FOUND)));
     JSONObject responseJson = (JSONObject) parser.parse(stringWriter.toString());
     String expectedJson = "{\"message\":\"Not found.\",\"status\":\"error\"}";
     JSONAssert.assertEquals(expectedJson, responseJson.toString(), JSONCompareMode.STRICT);

--- a/src/test/java/com/google/collegeplanner/SectionTest.java
+++ b/src/test/java/com/google/collegeplanner/SectionTest.java
@@ -209,11 +209,6 @@ public final class SectionTest {
     JSONObject responseObj = (JSONObject) parser.parse(stringWriter.toString());
     JSONArray sections = (JSONArray) responseObj.get("sections");
 
-    // Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
-    // System.out.println(gson.toJson(sections));
-    // JSONArray expected = (JSONArray) parser.parse(expectedJson);
-    // System.out.println(gson.toJson(expected));
-
     // Tests that response["sections"] exists
     Assert.assertNotNull(sections);
     // Checks that the correct number of JSON Objects are contained

--- a/src/test/java/com/google/collegeplanner/SectionTest.java
+++ b/src/test/java/com/google/collegeplanner/SectionTest.java
@@ -60,10 +60,8 @@ public final class SectionTest {
   LocalServiceTestHelper helper;
   ApiUtil apiUtil;
 
-  // JSONArray firstCoursesJson;
   JSONArray firstCourseJson;
   JSONArray firstSectionJson;
-  // JSONArray secondSectionJson;
   JSONArray emptyJson;
   JSONArray multipleMeetingsJson;
 

--- a/src/test/java/com/google/collegeplanner/SectionTest.java
+++ b/src/test/java/com/google/collegeplanner/SectionTest.java
@@ -30,8 +30,6 @@ import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.collegeplanner.servlets.ApiUtil;
 import com.google.collegeplanner.servlets.DatastoreServlet;
 import com.google.collegeplanner.servlets.SectionServlet;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
@@ -175,7 +173,7 @@ public final class SectionTest {
   }
 
   @Test
-  public void oneSectionMultipleMeetings() throws Exception {
+  public void servletResponseHasSections() throws Exception {
     String expectedJson = "[{"
         + "\"course_id\": \"AASP100\","
         + "\"section_id\": \"AASP100-0101\","


### PR DESCRIPTION
- CourseListServlet and Section now pull data directly from datastore and not the UMD API.

- Gson can directly serialize classes. `@SerializedName` was added to control what string each class variable gets serialized to when converting it into json.

- `Course`, `Section`, and `Meeting` classes were given constructors to convert datastore `Entity`/`EmbeddedEntity`s into their respective Course/Section/Meeting objects, which are then serialized into json.

- Add tests to make sure we're still getting correct output using datastore.

- Add tests to make sure the correct error codes are sent on error.

Closes #86.


